### PR TITLE
composer: add package self discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,49 +13,83 @@ cache:
     - $HOME/.composer/cache
 
 env:
-  LARAVEL_VERSION: "5.1.*"
-  ORCHESTRA_VERSION: "3.1.*"
+  PHPUNIT_VERSION: 4.8.*
+  LARAVEL_VERSION: 5.1.*
+  ORCHESTRA_VERSION: 3.1.*
 
 matrix:
   include:
-    - php: 5.5.9
-      env: LARAVEL_VERSION="5.1.*" ORCHESTRA_VERSION="3.1.*"
-    - php: 5.5.9
-      env: LARAVEL_VERSION="5.2.*" ORCHESTRA_VERSION="3.2.*"
+    - php: 5.5
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.2.*
+        ORCHESTRA_VERSION: 3.2.*
     - php: 5.6
-      env: LARAVEL_VERSION="5.1.*" ORCHESTRA_VERSION="3.1.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.2.*
+        ORCHESTRA_VERSION: 3.2.*
     - php: 5.6
-      env: LARAVEL_VERSION="5.2.*" ORCHESTRA_VERSION="3.2.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.3.*
+        ORCHESTRA_VERSION: 3.3.*
     - php: 5.6
-      env: LARAVEL_VERSION="5.3.*" ORCHESTRA_VERSION="3.3.*"
-    - php: 5.6
-      env: LARAVEL_VERSION="5.4.*" ORCHESTRA_VERSION="3.4.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.4.*
+        ORCHESTRA_VERSION: 3.4.*
     - php: 7.0
-      env: LARAVEL_VERSION="5.1.*" ORCHESTRA_VERSION="3.1.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.2.*
+        ORCHESTRA_VERSION: 3.2.*
     - php: 7.0
-      env: LARAVEL_VERSION="5.2.*" ORCHESTRA_VERSION="3.2.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.3.*
+        ORCHESTRA_VERSION: 3.3.*
     - php: 7.0
-      env: LARAVEL_VERSION="5.3.*" ORCHESTRA_VERSION="3.3.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.4.*
+        ORCHESTRA_VERSION: 3.4.*
     - php: 7.0
-      env: LARAVEL_VERSION="5.4.*" ORCHESTRA_VERSION="3.4.*"
+      env:
+        PHPUNIT_VERSION: 6.3.*
+        LARAVEL_VERSION: 5.5.*
+        ORCHESTRA_VERSION: 3.5.*
     - php: 7.1
-      env: LARAVEL_VERSION="5.1.*" ORCHESTRA_VERSION="3.1.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.2.*
+        ORCHESTRA_VERSION: 3.2.*
     - php: 7.1
-      env: LARAVEL_VERSION="5.2.*" ORCHESTRA_VERSION="3.2.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.3.*
+        ORCHESTRA_VERSION: 3.3.*
     - php: 7.1
-      env: LARAVEL_VERSION="5.3.*" ORCHESTRA_VERSION="3.3.*"
+      env:
+        PHPUNIT_VERSION: 4.8.*
+        LARAVEL_VERSION: 5.4.*
+        ORCHESTRA_VERSION: 3.4.*
     - php: 7.1
-      env: LARAVEL_VERSION="5.4.*" ORCHESTRA_VERSION="3.4.*"
+      env:
+        PHPUNIT_VERSION: 6.3.*
+        LARAVEL_VERSION: 5.5.*
+        ORCHESTRA_VERSION: 3.5.*
 
 before_install:
   - composer require "illuminate/support:${LARAVEL_VERSION}" --no-update --no-interaction
+  - composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --no-update --no-interaction --dev
   - composer require "orchestra/testbench:${ORCHESTRA_VERSION}" --no-update --no-interaction --dev
 
 install:
   - composer update --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - travis_wait vendor/bin/phpunit --coverage-text
 
 after_success:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All Notable changes to `pagarme-laravel` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 0.3.0 - 2017-09-19
+
+### Added
+- Support to Laravel 5.5
+- Support to [package self-discovery](https://laravel.com/docs/5.5/packages#package-discovery)
+
 ## 0.2.0 - 2017-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ composer require flyingluscas/pagarme-laravel
 
 Set up the **service provider** and the **facade** in your **config/app.php** file.
 
+> You can skip this step on Laravel 5.5 due to the [self-discovery package feature][link-laravel-self-discovery].
+
 ``` php
 'providers' => [
     FlyingLuscas\PagarMeLaravel\PagarMeServiceProvider::class,
@@ -127,4 +129,5 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [link-contributors]: ../../contributors
 [link-pagarme-wiki]: https://github.com/pagarme/pagarme-php/wiki
 [link-pagarme-dash]: https://dashboard.pagar.me/#/myaccount/apikeys
-[link-pagarme-checkout-form]: https://docs.pagar.me/docs/inserindo-o-formulario
+[link-pagarme-checkout-form]: https://docs.pagar.me/v2017-07-17/docs/inserindo-o-formulario
+[link-laravel-self-discovery]: https://laravel.com/docs/5.5/packages#package-discovery

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,15 @@
     },
     "scripts": {
         "test": "phpunit --colors=always"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "FlyingLuscas\\PagarMeLaravel\\PagarMeServiceProvider"
+            ],
+            "aliases": {
+                "PagarMe": "FlyingLuscas\\PagarMeLaravel\\PagarMeFacade"
+            }
+        }
     }
 }


### PR DESCRIPTION
- Add support to the package self-discovery in the composer file.
- Update README to document this feature.
- Update Travis CI settings to also run tests on Laravel 5.5